### PR TITLE
Modificação no GameManager

### DIFF
--- a/src/core/manager.py
+++ b/src/core/manager.py
@@ -5,13 +5,16 @@ from .data import Blittable
 from .maths import Vector2
 
 class GameManager:
-    def __init__(self, title, win_size, icon):
+    def __init__(self, title, win_size):
         self.title = title
         self.win_size = tuple(win_size)
 
         self._screen = pygame.display.set_mode(self.win_size)
         pygame.display.set_caption(self.title)
+
+    def set_icon(self, icon):
         pygame.display.set_icon(icon.into_pygame())
+        
 
     def fill_screen(self, color):
         self._screen.fill(color)

--- a/src/core/resource.py
+++ b/src/core/resource.py
@@ -3,6 +3,7 @@ class ResourceManager:
         self._resource_wrapper = resource_wrapper
         self._resource_map = {}
         for k, r in resources.items():
+            print(k)
             self.add_resource(k, r)
         
     def add_resource(self, key, resource):

--- a/src/game/__init__.py
+++ b/src/game/__init__.py
@@ -24,7 +24,6 @@ class GameCore:
 
     # TODO: document most variables inside this function
     def __init__(self, save_path, audio_path, resources_path):
-        pygame.display.set_mode((1, 1))
         self.deltatime = DeltaTime()
         # paths
         self.save_path = Path(save_path)
@@ -68,6 +67,15 @@ class GameCore:
             fpath = self.resources_path / x
             with open(fpath, "r") as f:
                 return PygameSurface(pygame.image.load(f).convert_alpha())
+
+        self.manager = GameManager(
+            title = "({}x{}) {}".format(
+                self.config.win_size.x,
+                self.config.win_size.y,
+                self.config.title,
+            ),
+            win_size = self.config.win_size,
+        )
 
         self.gfx = ResourceManager(
             load_gfx_resource,
@@ -119,6 +127,8 @@ class GameCore:
                 Gfx.STARTER_TIP: "ui/starter_tip.png",
             }
         )
+
+        self.manager.set_icon(self.gfx.get(Gfx.ICON))
 
         def load_aud_resource(x):
             fpath = self.audio_path / x
@@ -229,16 +239,6 @@ class GameCore:
         self.c_debug_text = None
         self.c_previous_score = 0
         self.c_score_text_rendered = None
-
-        self.manager = GameManager(
-            title = "({}x{}) {}".format(
-                self.config.win_size.x,
-                self.config.win_size.y,
-                self.config.title,
-            ),
-            win_size = self.config.win_size,
-            icon = self.gfx.get(Gfx.ICON),
-        )
 
     def main_loop(self):
         self.prepare_turn()


### PR DESCRIPTION
Depois da otimização que trouxe de volta os 60 FPS do jogo, para que não inicializasse uma tela antes de carregar os recursos e inicializar de novo depois, eu modifiquei o sistema para definir o ícone depois de carregar a tela e os recursos.

O que acha @YohananDiamond 